### PR TITLE
Switching search results interface

### DIFF
--- a/Test/Unit/Traits/RepositorySearchResultBuilderTraitTest.php
+++ b/Test/Unit/Traits/RepositorySearchResultBuilderTraitTest.php
@@ -10,17 +10,17 @@ declare(strict_types=1);
 
 namespace MSlwk\RepositorySearchResultBuilder\Test\Unit\Traits;
 
-use Magento\Framework\DataObject;
-use PHPUnit\Framework\TestCase;
 use Magento\Catalog\Model\ResourceModel\Product\Collection;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
-use Magento\Framework\Api\SearchCriteriaInterface;
-use Magento\Framework\Data\SearchResultInterface;
-use Magento\Framework\Data\SearchResultInterfaceFactory;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use Magento\Framework\Api\Filter;
 use Magento\Framework\Api\Search\FilterGroup;
+use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\Api\SearchResultsInterface;
+use Magento\Framework\Api\SearchResultsInterfaceFactory;
 use Magento\Framework\Api\SortOrder;
+use Magento\Framework\DataObject;
+use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 
 /**
  * Class RepositorySearchResultBuilderTraitTest
@@ -34,9 +34,9 @@ class RepositorySearchResultBuilderTraitTest extends TestCase
     private $collectionFactory;
 
     /**
-     * @var MockObject|SearchResultInterfaceFactory
+     * @var MockObject|SearchResultsInterfaceFactory
      */
-    private $searchResultFactory;
+    private $searchResultsFactory;
 
     /**
      * @var RepositoryTestDouble
@@ -51,11 +51,11 @@ class RepositorySearchResultBuilderTraitTest extends TestCase
         $this->collectionFactory = $this->getMockBuilder(CollectionFactory::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->searchResultFactory = $this->getMockBuilder(SearchResultInterfaceFactory::class)
+        $this->searchResultsFactory = $this->getMockBuilder(SearchResultsInterfaceFactory::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->repository = new RepositoryTestDouble($this->collectionFactory, $this->searchResultFactory);
+        $this->repository = new RepositoryTestDouble($this->collectionFactory, $this->searchResultsFactory);
     }
 
     /**
@@ -112,7 +112,7 @@ class RepositorySearchResultBuilderTraitTest extends TestCase
             ->method('create')
             ->will($this->returnValue($collection));
 
-        $searchResults = $this->getMockBuilder(SearchResultInterface::class)
+        $searchResults = $this->getMockBuilder(SearchResultsInterface::class)
             ->setMethods(
                 [
                     'setSearchCriteria',
@@ -125,7 +125,7 @@ class RepositorySearchResultBuilderTraitTest extends TestCase
             )
             ->getMock();
 
-        $this->searchResultFactory->expects($this->once())
+        $this->searchResultsFactory->expects($this->once())
             ->method('create')
             ->will($this->returnValue($searchResults));
 

--- a/Test/Unit/Traits/RepositoryTestDouble.php
+++ b/Test/Unit/Traits/RepositoryTestDouble.php
@@ -12,10 +12,10 @@ namespace MSlwk\RepositorySearchResultBuilder\Test\Unit\Traits;
 
 use Magento\Catalog\Model\ResourceModel\Product\Collection;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
-use MSlwk\RepositorySearchResultBuilder\Traits\RepositorySearchResultBuilderTrait;
 use Magento\Framework\Api\SearchCriteriaInterface;
-use Magento\Framework\Data\SearchResultInterface;
-use Magento\Framework\Data\SearchResultInterfaceFactory;
+use Magento\Framework\Api\SearchResultsInterface;
+use Magento\Framework\Api\SearchResultsInterfaceFactory;
+use MSlwk\RepositorySearchResultBuilder\Traits\RepositorySearchResultBuilderTrait;
 
 /**
  * Class RepositoryTestDouble
@@ -31,28 +31,28 @@ class RepositoryTestDouble
     private $collectionFactory;
 
     /**
-     * @var SearchResultInterfaceFactory
+     * @var SearchResultsInterfaceFactory
      */
-    private $searchResultFactory;
+    private $searchResultsFactory;
 
     /**
      * RepositoryTestDouble constructor.
      * @param CollectionFactory $collectionFactory
-     * @param SearchResultInterfaceFactory $searchResultFactory
+     * @param SearchResultsInterfaceFactory $searchResultFactory
      */
     public function __construct(
         CollectionFactory $collectionFactory,
-        SearchResultInterfaceFactory $searchResultFactory
+        SearchResultsInterfaceFactory $searchResultsFactory
     ) {
         $this->collectionFactory = $collectionFactory;
-        $this->searchResultFactory = $searchResultFactory;
+        $this->searchResultsFactory = $searchResultsFactory;
     }
 
     /**
      * @param SearchCriteriaInterface $searchCriteria
-     * @return SearchResultInterface
+     * @return SearchResultsInterface
      */
-    public function getList(SearchCriteriaInterface $searchCriteria): SearchResultInterface
+    public function getList(SearchCriteriaInterface $searchCriteria): SearchResultsInterface
     {
         /** @var Collection $collection */
         $collection = $this->collectionFactory->create();
@@ -61,8 +61,8 @@ class RepositoryTestDouble
         $this->addSortOrdersToCollection($searchCriteria, $collection);
         $this->addPagingToCollection($searchCriteria, $collection);
 
-        /** @var SearchResultInterface $searchResults */
-        $searchResults = $this->searchResultFactory->create();
+        /** @var SearchResultsInterface $searchResults */
+        $searchResults = $this->searchResultsFactory->create();
         return $this->buildSearchResult($searchCriteria, $searchResults, $collection);
     }
 }

--- a/Traits/RepositorySearchResultBuilderTrait.php
+++ b/Traits/RepositorySearchResultBuilderTrait.php
@@ -11,8 +11,8 @@ declare(strict_types=1);
 namespace MSlwk\RepositorySearchResultBuilder\Traits;
 
 use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\Api\SearchResultsInterface;
 use Magento\Framework\Api\SortOrder;
-use Magento\Framework\Data\SearchResultInterface;
 use Magento\Framework\Data\Collection\AbstractDb;
 
 /**
@@ -67,15 +67,15 @@ trait RepositorySearchResultBuilderTrait
 
     /**
      * @param SearchCriteriaInterface $searchCriteria
-     * @param SearchResultInterface $searchResults
+     * @param SearchResultsInterface $searchResults
      * @param AbstractDb $collection
-     * @return SearchResultInterface
+     * @return SearchResultsInterface
      */
     protected function buildSearchResult(
         SearchCriteriaInterface $searchCriteria,
-        SearchResultInterface $searchResults,
+        SearchResultsInterface $searchResults,
         AbstractDb $collection
-    ): SearchResultInterface {
+    ): SearchResultsInterface {
         $searchResults->setSearchCriteria($searchCriteria);
         $searchResults->setItems($collection->getItems());
         $searchResults->setTotalCount($collection->getSize());


### PR DESCRIPTION
Majority of repositories across Magento vendor uses different `SearchResultInterface`. In PR I replaced it with other, which seems to be correct. Former one is used only in a few repositories and requires some special steps to be used in custom repositories. If we take a look at former codebase, we can notice in our trait even some methods don't exist (but they are available in `Magento\Framework\Api\SearchResultsInterface` ).